### PR TITLE
Update Sonatype endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ run safely in parallel.
 You can find our documentation [here](https://carlspring.github.io/idempotence/).
 
 [![Maven Release Version](https://img.shields.io/maven-central/v/org.carlspring.testing.idempotence/idempotence-core)](https://repo.maven.apache.org/maven2/org/carlspring/testing/idempotence/idempotence-core/)
-[![Maven Snapshot Version](https://img.shields.io/nexus/s/org.carlspring.testing.idempotence/idempotence-core?server=https%3A%2F%2Foss.sonatype.org)](https://oss.sonatype.org/content/repositories/snapshots/org/carlspring/testing/idempotence/idempotence-core/)
+[![Maven Snapshot Version](https://img.shields.io/nexus/s/org.carlspring.testing.idempotence/idempotence-core?server=https%3A%2F%2Fs01.oss.sonatype.org)](https://s01.oss.sonatype.org/content/repositories/snapshots/org/carlspring/testing/idempotence/idempotence-core/)

--- a/idempotence-core/pom.xml
+++ b/idempotence-core/pom.xml
@@ -101,12 +101,12 @@
         <repository>
             <id>central</id>
             <name>Maven Central Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
             <id>central</id>
             <name>Maven Central Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 

--- a/idempotence-gradle-integration-tests/pom.xml
+++ b/idempotence-gradle-integration-tests/pom.xml
@@ -80,12 +80,12 @@
         <repository>
             <id>central</id>
             <name>Maven Central Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
             <id>central</id>
             <name>Maven Central Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 

--- a/idempotence-gradle/pom.xml
+++ b/idempotence-gradle/pom.xml
@@ -113,12 +113,12 @@
         <repository>
             <id>central</id>
             <name>Maven Central Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
             <id>central</id>
             <name>Maven Central Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 

--- a/idempotence-maven/pom.xml
+++ b/idempotence-maven/pom.xml
@@ -122,12 +122,12 @@
         <repository>
             <id>central</id>
             <name>Maven Central Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
             <id>central</id>
             <name>Maven Central Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 

--- a/idempotence-parent/pom.xml
+++ b/idempotence-parent/pom.xml
@@ -94,6 +94,17 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>
@@ -180,12 +191,12 @@
         <repository>
             <id>central</id>
             <name>Maven Central Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
             <id>central</id>
             <name>Maven Central Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,12 @@
         <repository>
             <id>central</id>
             <name>Maven Central Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
             <id>central</id>
             <name>Maven Central Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
## Summary
- update snapshot badge and POM distributionManagement URLs to use `s01.oss.sonatype.org`
- configure `central-publishing-maven-plugin` for Central deployment

## Testing
- `mvn -q test` *(fails: network unreachable during plugin resolution)*

------
https://chatgpt.com/codex/tasks/task_e_6865ccbef6948322999269a19b6f1dc5